### PR TITLE
Refactor existing pages to make use of Bootstrap components

### DIFF
--- a/client/src/components/Grid/index.js
+++ b/client/src/components/Grid/index.js
@@ -1,7 +1,5 @@
 import React from "react";
 
-// Exporting the Container, Row, and Col components from this file
-
 // This Container component allows us to use a bootstrap container without worrying about class names
 export function Container({ styles, children }) {
   return <div className={`container ${styles}`}>{children}</div>;

--- a/client/src/components/Grid/index.js
+++ b/client/src/components/Grid/index.js
@@ -3,8 +3,8 @@ import React from "react";
 // Exporting the Container, Row, and Col components from this file
 
 // This Container component allows us to use a bootstrap container without worrying about class names
-export function Container({ fluid, children }) {
-  return <div className={`container${fluid ? "-fluid" : ""}`}>{children}</div>;
+export function Container({ styles, children }) {
+  return <div className={`container ${styles}`}>{children}</div>;
 }
 
 // This Row component lets us use a bootstrap row without having to think about class names

--- a/client/src/components/Grid/index.js
+++ b/client/src/components/Grid/index.js
@@ -8,8 +8,8 @@ export function Container({ fluid, children }) {
 }
 
 // This Row component lets us use a bootstrap row without having to think about class names
-export function Row({ fluid, children }) {
-  return <div className={`row${fluid ? "-fluid" : ""}`}>{children}</div>;
+export function Row({ styles, children }) {
+  return <div className={`row ${styles}`}>{children}</div>;
 }
 
 // This Col component lets us size bootstrap columns with less syntax

--- a/client/src/pages/Home/Home.js
+++ b/client/src/pages/Home/Home.js
@@ -6,13 +6,13 @@ import { Container, Row, Col } from "../../components/Grid";
 function Home() {
   return (
     <Container className="bg-transparent">
-      <div className="row justify-content-center align-items-center text-center text-white">
+      <Row styles="justify-content-center align-items-center text-center text-white">
         <div className="col-lg-8">
           <h1 className="mt-5" id="mast">Beadli</h1>
             <p id="subtitle">Make interesting designs with beads.</p>
             <Link className="btn btn-outline-light btn-lg" to="/login" role="button">Get Started</Link>
         </div>
-      </div>
+      </Row>
     </Container>
   );
 }

--- a/client/src/pages/Home/Home.js
+++ b/client/src/pages/Home/Home.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import "./style.css";
-// import { Container, Row, Col } from "../../components/Grid";
+import { Container, Row, Col } from "../../components/Grid";
 
 function Home() {
   return (
-    <div className="container bg-transparent">
+    <Container className="bg-transparent">
       <div className="row justify-content-center align-items-center text-center text-white">
         <div className="col-lg-8">
           <h1 className="mt-5" id="mast">Beadli</h1>
@@ -13,7 +13,7 @@ function Home() {
             <Link className="btn btn-outline-light btn-lg" to="/login" role="button">Get Started</Link>
         </div>
       </div>
-    </div>
+    </Container>
   );
 }
 

--- a/client/src/pages/Home/Home.js
+++ b/client/src/pages/Home/Home.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import "./style.css";
 import { Container, Row, Col } from "../../components/Grid";
+import "./style.css";
 
 function Home() {
   return (
     <Container className="bg-transparent">
       <Row styles="justify-content-center align-items-center text-center text-white">
-        <div className="col-lg-8">
+        <Col size="lg-8">
           <h1 className="mt-5" id="mast">Beadli</h1>
             <p id="subtitle">Make interesting designs with beads.</p>
             <Link className="btn btn-outline-light btn-lg" to="/login" role="button">Get Started</Link>
-        </div>
+        </Col>
       </Row>
     </Container>
   );

--- a/client/src/pages/Home/style.css
+++ b/client/src/pages/Home/style.css
@@ -4,7 +4,7 @@
 }
 
 .container {
-  margin-top: 9em;
+  margin-top: 10%;
 }
 
 #mast {

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -1,12 +1,13 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { Container, Row, Col } from "../../components/Grid";
 import "./style.css";
 
 function Login() {
   return (
-    <div className="container well">
-      <div className="row justify-content-center align-items-center text-center">
-        <div className="col-lg-10">
+    <Container styles="well">
+      <Row styles="justify-content-center align-items-center text-center">
+        <Col size="lg-10">
           <div className="card-body">
           <h1 className="mb-3">Login</h1>
             <form className="login">
@@ -36,9 +37,9 @@ function Login() {
               Need an account? <Link to="/signup">Sign up</Link>.
             </p>
           </div>
-        </div>
-      </div>
-    </div>
+        </Col>
+      </Row>
+    </Container>
   );
 }
 

--- a/client/src/pages/Signup/Signup.js
+++ b/client/src/pages/Signup/Signup.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
-// import "./style.css";
+import { Container, Row, Col } from "../../components/Grid";
 
 function Login() {
   return (
-    <div className="container well">
-      <div className="row justify-content-center align-items-center text-center">
-        <div className="col-lg-10">
+    <Container styles="well">
+      <Row styles="justify-content-center align-items-center text-center">
+        <Col size="lg-10">
           <div className="card-body">
           <h1 className="mb-3">Sign Up</h1>
             <form className="signup">
@@ -45,9 +45,9 @@ function Login() {
               Already have an account? <Link to="/login">Login</Link>.
             </p>
           </div>
-        </div>
-      </div>
-    </div>
+        </Col>
+      </Row>
+    </Container>
   );
 }
 


### PR DESCRIPTION
This refactors the existing pages I made last night to make use of the functional components that we already had. I did modify the boilerplate Bootstrap components so that we can pass in classes (as "styles") at the page level; the prop name for these is "styles", since Bootstrap basically treats classes as CSS styles. 