### PR TITLE
Temporary workaround for establishing access to protected routes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,31 +6,7 @@ import Login from "./pages/Login/Login";
 import Signup from "./pages/Signup/Signup";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import Nav from "./components/Nav";
-import API from "./utils/userAPI"
-
-const PrivateRoute = ({ component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={props =>
-      isAuthed() === true ? (
-        <Component {...props} {...rest} />
-      ) : (
-        <Redirect
-          to={{
-            pathname: "/login",
-            state: { from: props.location }
-          }}
-        />
-      )
-    }
-  />
-);
-
-const isAuthed = () => {
-  API.checkAuthStatus().then(res => {
-    return res.data.isLoggedIn;
-  });
-};
+import ProtectedRoute from "./components/ProtectedRoute";
 
 class App extends Component {
   constructor(props) {
@@ -51,7 +27,7 @@ class App extends Component {
             <Route exact path="/" component={Home} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/signup" component={Signup} />
-            <PrivateRoute exact path="/dashboard" component={Dashboard} />
+            <ProtectedRoute exact path="/dashboard" component={Dashboard} />
             <Route component={NoMatch} />
           </Switch>
         </div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,10 @@
 import React, { Component } from "react";
-import { BrowserRouter as Router, Route, Switch, Redirect } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect
+} from "react-router-dom";
 import Home from "./pages/Home/Home";
 import NoMatch from "./pages/NoMatch";
 import Login from "./pages/Login/Login";
@@ -7,6 +12,7 @@ import Signup from "./pages/Signup/Signup";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import Nav from "./components/Nav";
 import ProtectedRoute from "./components/ProtectedRoute";
+import userAPI from "./utils/userAPI";
 
 class App extends Component {
   constructor(props) {
@@ -16,13 +22,21 @@ class App extends Component {
     };
   }
 
+  logout = () => {
+    userAPI.logOut().then(() => {
+      localStorage.removeItem("beadli");
+      window.location.replace("/");
+      // return <Redirect to="/" />;
+    });
+  };
+
   // I think we'll need to call userAPI.checkAuth() when componentDidMount so that we can check if auth status at the root level. This will then allow us to render private routes (See https://github.com/shouheiyamauchi/react-passport-example/blob/master/client/src/Main.js).
 
   render() {
     return (
       <Router>
         <div>
-          <Nav isAuthed={this.state.authenticated} />
+          <Nav logout={this.logout} />
           <Switch>
             <Route exact path="/" component={Home} />
             <Route exact path="/login" component={Login} />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,7 +3,7 @@ import {
   BrowserRouter as Router,
   Route,
   Switch,
-  Redirect
+  // Redirect
 } from "react-router-dom";
 import Home from "./pages/Home/Home";
 import NoMatch from "./pages/NoMatch";

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,10 +1,36 @@
 import React, { Component } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Switch, Redirect } from "react-router-dom";
 import Home from "./pages/Home/Home";
 import NoMatch from "./pages/NoMatch";
 import Login from "./pages/Login/Login";
 import Signup from "./pages/Signup/Signup";
+import Dashboard from "./pages/Dashboard/Dashboard";
 import Nav from "./components/Nav";
+import API from "./utils/userAPI"
+
+const PrivateRoute = ({ component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      isAuthed() === true ? (
+        <Component {...props} {...rest} />
+      ) : (
+        <Redirect
+          to={{
+            pathname: "/login",
+            state: { from: props.location }
+          }}
+        />
+      )
+    }
+  />
+);
+
+const isAuthed = () => {
+  API.checkAuthStatus().then(res => {
+    return res.data.isLoggedIn;
+  });
+};
 
 class App extends Component {
   constructor(props) {
@@ -25,6 +51,7 @@ class App extends Component {
             <Route exact path="/" component={Home} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/signup" component={Signup} />
+            <PrivateRoute exact path="/dashboard" component={Dashboard} />
             <Route component={NoMatch} />
           </Switch>
         </div>

--- a/client/src/components/Nav/index.js
+++ b/client/src/components/Nav/index.js
@@ -47,7 +47,7 @@ function Nav(props) {
               >
                 My Account
               </a>
-              <div className="dropdown-menu" aria-labelledby="navbarDropdown">
+              <div className="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                 <Link className="dropdown-item" to="/dashboard">
                   Dashboard
                 </Link>
@@ -57,11 +57,6 @@ function Nav(props) {
               </div>
             </li>
           ) : (
-            // <li className="nav-item">
-            //   <Link className="nav-link" to="/dashboard">
-            //     My Account
-            //   </Link>
-            // </li>
             <li className="nav-item">
               <Link className="nav-link" to="/login">
                 Login

--- a/client/src/components/Nav/index.js
+++ b/client/src/components/Nav/index.js
@@ -34,13 +34,34 @@ function Nav(props) {
               Browse
             </Link>
           </li>
-          {props.isAuthed ? (
-            <li className="nav-item">
-              <Link className="nav-link" to="/dashboard">
+          {localStorage.getItem("beadli") ? (
+            <li className="nav-item dropdown">
+              <a
+                className="nav-link dropdown-toggle"
+                href="#"
+                id="navbarDropdown"
+                role="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
                 My Account
-              </Link>
+              </a>
+              <div className="dropdown-menu" aria-labelledby="navbarDropdown">
+                <Link className="dropdown-item" to="/dashboard">
+                  Dashboard
+                </Link>
+                <a className="dropdown-item" onClick={props.logout} href="#">
+                  Logout
+                </a>
+              </div>
             </li>
           ) : (
+            // <li className="nav-item">
+            //   <Link className="nav-link" to="/dashboard">
+            //     My Account
+            //   </Link>
+            // </li>
             <li className="nav-item">
               <Link className="nav-link" to="/login">
                 Login

--- a/client/src/components/Nav/index.js
+++ b/client/src/components/Nav/index.js
@@ -51,9 +51,9 @@ function Nav(props) {
                 <Link className="dropdown-item" to="/dashboard">
                   Dashboard
                 </Link>
-                <a className="dropdown-item" onClick={props.logout} href="#">
+                <Link className="dropdown-item" onClick={props.logout} to="#">
                   Logout
-                </a>
+                </Link>
               </div>
             </li>
           ) : (

--- a/client/src/components/Nav/style.css
+++ b/client/src/components/Nav/style.css
@@ -6,4 +6,3 @@
 .navbar-brand {
   font-family: "Beadli";
 }
-

--- a/client/src/components/ProtectedRoute.js
+++ b/client/src/components/ProtectedRoute.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { Route, Redirect } from "react-router-dom";
 // import API from "../utils/userAPI";
 

--- a/client/src/components/ProtectedRoute.js
+++ b/client/src/components/ProtectedRoute.js
@@ -1,0 +1,25 @@
+import React, { Component } from "react";
+import { Route, Redirect } from "react-router-dom";
+// import API from "../utils/userAPI";
+
+function ProtectedRoute({ component: Component, ...rest }) {
+  return (
+    <Route
+      {...rest}
+      render={props =>
+        localStorage.getItem("beadli") ? (
+          <Component {...props} />
+        ) : (
+          <Redirect
+            to={{
+              pathname: "/login",
+              state: { from: props.location }
+            }}
+          />
+        )
+      }
+    />
+  );
+}
+
+export default ProtectedRoute;

--- a/client/src/pages/Dashboard/Dashboard.js
+++ b/client/src/pages/Dashboard/Dashboard.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+function NoMatch() {
+    return (
+        <div>
+            This is the protected dashboard.
+        </div>
+    );
+};
+
+export default NoMatch;

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
-import { Link, Redirect } from "react-router-dom";
+import { Link, 
+  // Redirect 
+} from "react-router-dom";
 import { Container, Row, Col } from "../../components/Grid";
 import "./style.css";
 import userAPI from "../../utils/userAPI";
@@ -87,6 +89,7 @@ class Login extends Component {
   render() {
     if (this.state.isLoggedIn) {
       return window.location.replace("/dashboard");
+      // return <Redirect to="/dashboard" />
     }
 
     return (

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -33,7 +33,7 @@ class Login extends Component {
     console.log(this.state.isLoggedIn);
     userAPI.logIn(this.state.email, this.state.password)
       .then(res => {
-        console.log(this.state.isLoggedIn)
+        localStorage.setItem("beadli", res.data._id);
         this.setState({ 
           isLoggedIn: true 
         });
@@ -48,7 +48,7 @@ class Login extends Component {
         }
         else {
           this.setState({
-            notification: "Something went wrong (error code ${err})"
+            notification: `Something went wrong (error code ${err})`
           }, 
             () => alert(this.state.notification)
           );

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -86,7 +86,7 @@ class Login extends Component {
 
   render() {
     if (this.state.isLoggedIn) {
-      return <Redirect to="/dashboard" />;
+      return window.location.replace("/dashboard");
     }
 
     return (

--- a/client/src/utils/userAPI.js
+++ b/client/src/utils/userAPI.js
@@ -22,7 +22,7 @@ export default {
 
   // Get request to logout the current user. Should return a boolean response.
   logOut: function() {
-    return axios.get("/api/logout");
+    return axios.get("/logout");
   },
 
   // Send a request to the api/user endpoint to see if req.user exists.


### PR DESCRIPTION
This pull request uses session storage to implement a naive token system for allowing users to access a protected route on the client side. This is imperfect and should be fixed -- for instance, I had to do a page refresh on login and logout in order to grab and delete the session token. However, this workaround should give us the ability to focus on other more pertinent functionality with a basic protected route strategy in place.