### PR TITLE
More modals

### DIFF
--- a/client/src/components/Modals/DeleteModal.js
+++ b/client/src/components/Modals/DeleteModal.js
@@ -48,7 +48,7 @@ class DeleteModal extends Component {
             Close
           </Button>
           <Button
-            variant="light"
+            variant="btn btn-outline-danger"
             id="delete-button"
             onClick={event =>
               this.props.deleteDesign(

--- a/client/src/components/Modals/PublishModal.js
+++ b/client/src/components/Modals/PublishModal.js
@@ -117,7 +117,7 @@ class PublishModal extends Component {
             Close
           </Button>
           <Button
-            variant="light"
+            variant="btn btn-outline-success"
             id="publish-button"
             onClick={() =>
               this.props.publish(this.props.id, {

--- a/client/src/components/Modals/SimpleModal.js
+++ b/client/src/components/Modals/SimpleModal.js
@@ -15,18 +15,21 @@ class SimpleModal extends Component {
             {this.props.buttonRemainText}
           </Button>
           {this.props.buttonActionFunc ? (
-            <Button variant="light" onClick={this.props.buttonActionFunc}>
+            <Button
+              variant={this.props.buttonVariant}
+              onClick={this.props.buttonActionFunc}
+            >
               {this.props.buttonActionText}
             </Button>
           ) : (
-            <Button variant="light">
-              <Link
-                to={this.props.buttonActionLink}
-                style={{ textDecoration: "none", color: "black" }}
-              >
-                {this.props.buttonActionText}
-              </Link>
-            </Button>
+            <Link
+              to={{
+                pathname: this.props.buttonActionLink
+              }}
+              className={this.props.buttonVariant}
+            >
+              {this.props.buttonActionText}
+            </Link>
           )}
         </Modal.Footer>
       </Modal>

--- a/client/src/components/Modals/UnfavoriteModal.js
+++ b/client/src/components/Modals/UnfavoriteModal.js
@@ -50,7 +50,7 @@ class UnfavoriteModal extends Component {
             Close
           </Button>
           <Button
-            variant="light"
+            variant="btn btn-outline-danger"
             id="publish-button"
             onClick={event =>
               this.props.unfavorite(
@@ -60,7 +60,7 @@ class UnfavoriteModal extends Component {
               )
             }
           >
-            Confirm
+            Unfavorite
           </Button>
         </Modal.Footer>
       </Modal>

--- a/client/src/pages/Create/Create.js
+++ b/client/src/pages/Create/Create.js
@@ -252,6 +252,7 @@ class Create extends Component {
       title: "Design Saved",
       body:
         "A draft of your design has been saved to your Dashboard. You can keep working on it here, or visit your Dashboard to publish or edit it later.",
+      buttonVariant: "btn btn-outline-info",
       buttonActionText: "View Dashboard",
       buttonActionLink: "/dashboard",
       buttonRemainText: "Keep Working"
@@ -261,6 +262,7 @@ class Create extends Component {
       title: "Clear Board",
       body:
         "Are you sure that you want to clear the board? This action cannot be undone.",
+      buttonVariant: "outline-danger",
       buttonActionText: "Clear Board",
       buttonActionFunc: this.clearBoard,
       buttonRemainText: "Cancel"
@@ -322,11 +324,6 @@ class Create extends Component {
               show={this.state.modalShow}
               onHide={this.modalClose}
               {...saveModal}
-              // title="Design Saved"
-              // body="A draft of your design has been saved to your Dashboard. You can keep working on it here, or visit your Dashboard to publish or edit it later."
-              // buttonActionText="View Dashboard"
-              // buttonActionLink="/dashboard"
-              // buttonRemainText="Keep Working"
             />
           ) : (
             <SimpleModal

--- a/client/src/pages/Create/Create.js
+++ b/client/src/pages/Create/Create.js
@@ -30,6 +30,7 @@ class Create extends Component {
       title: "",
       colorName: "",
       modalShow: false,
+      modalType: "",
       dimension: 2
     };
   }
@@ -126,7 +127,15 @@ class Create extends Component {
   clearBoard = () => {
     this.setState({
       squares: this.genBlankBoard(),
-      history: []
+      history: [],
+      modalShow: false
+    });
+  };
+
+  triggerClearBoard = () => {
+    this.setState({
+      modalShow: true,
+      modalType: "clear"
     });
   };
 
@@ -172,7 +181,7 @@ class Create extends Component {
               designId: res.data._id
             },
             // () => alert(`Design saved!`)
-            () => this.setState({ modalShow: true })
+            () => this.setState({ modalShow: true, modalType: "save" })
           );
         })
         .catch(err => alert(`Hmm something went wrong (${err}). Try again!`));
@@ -187,7 +196,7 @@ class Create extends Component {
         .then(res => {
           // console.log(res);
           // alert(`Design saved!`);
-          this.setState({ modalShow: true });
+          this.setState({ modalShow: true, modalType: "save" });
         })
         .catch(err => alert(`Hmm something went wrong (${err}). Try again!`));
     }
@@ -238,6 +247,25 @@ class Create extends Component {
   modalClose = () => this.setState({ modalShow: false });
 
   render() {
+    // Props objects to conditionally render the SimpleModal
+    const saveModal = {
+      title: "Design Saved",
+      body:
+        "A draft of your design has been saved to your Dashboard. You can keep working on it here, or visit your Dashboard to publish or edit it later.",
+      buttonActionText: "View Dashboard",
+      buttonActionLink: "/dashboard",
+      buttonRemainText: "Keep Working"
+    };
+
+    const clearModal = {
+      title: "Clear Board",
+      body:
+        "Are you sure that you want to clear the board? This action cannot be undone.",
+      buttonActionText: "Clear Board",
+      buttonActionFunc: this.clearBoard,
+      buttonRemainText: "Cancel"
+    };
+
     return (
       <Fragment>
         <Container styles="well">
@@ -284,20 +312,29 @@ class Create extends Component {
 
               <ButtonGroup
                 button1={<UndoButton onClick={this.undo} />}
-                button2={<ClearButton onClick={this.clearBoard} />}
+                button2={<ClearButton onClick={this.triggerClearBoard} />}
                 button3={<SaveButton onClick={this.save} />}
               />
             </Col>
           </Row>
-          <SimpleModal
-            show={this.state.modalShow}
-            onHide={this.modalClose}
-            title="Design Saved"
-            body="A draft of your design has been saved to your Dashboard. You can keep working on it here, or visit your Dashboard to publish or edit it later."
-            buttonActionText="View Dashboard"
-            buttonActionLink="/dashboard"
-            buttonRemainText="Keep Working"
-          />
+          {this.state.modalType === "save" ? (
+            <SimpleModal
+              show={this.state.modalShow}
+              onHide={this.modalClose}
+              {...saveModal}
+              // title="Design Saved"
+              // body="A draft of your design has been saved to your Dashboard. You can keep working on it here, or visit your Dashboard to publish or edit it later."
+              // buttonActionText="View Dashboard"
+              // buttonActionLink="/dashboard"
+              // buttonRemainText="Keep Working"
+            />
+          ) : (
+            <SimpleModal
+              show={this.state.modalShow}
+              onHide={this.modalClose}
+              {...clearModal}
+            />
+          )}
         </Container>
       </Fragment>
     );


### PR DESCRIPTION
This PR conditionally renders the save and clear board modals on the Create page, as well as restyles the confirmation buttons for all of the other app's confirmation buttons (red for delete, green for confirm, etc).